### PR TITLE
Support SHA256 for OP

### DIFF
--- a/lib/sepa/application_request.rb
+++ b/lib/sepa/application_request.rb
@@ -177,7 +177,7 @@ module Sepa
         set_node('Environment', @environment.to_s.upcase)
         set_node("CustomerId", @customer_id)
         set_node("Timestamp", iso_time)
-        set_node("SoftwareId", "Sepa Transfer Library #{VERSION}")
+        set_node("SoftwareId", @software_id || "Sepa Transfer Library #{VERSION}")
         set_node("Command", pretty_command) unless @command == :renew_certificate
       end
 

--- a/lib/sepa/banks/op/soap_op.rb
+++ b/lib/sepa/banks/op/soap_op.rb
@@ -10,5 +10,9 @@ module Sepa
       def cert_ns
         OP_PKI
       end
+
+      def digest_method
+        :sha256
+      end
   end
 end

--- a/lib/sepa/client.rb
+++ b/lib/sepa/client.rb
@@ -182,6 +182,10 @@ module Sepa
     # @return [SoapBuilder]
     attr_reader :soap
 
+    # Software id string that is sent to the bank as part of the application request.
+    # Defaults to "Sepa Transfer Library <version>"
+    attr_accessor :software_id
+
     # The list of banks that are currently supported by this gem
     BANKS = %i(
       danske

--- a/lib/sepa/soap_builder.rb
+++ b/lib/sepa/soap_builder.rb
@@ -187,7 +187,7 @@ module Sepa
         set_node @template, 'bxd|RequestId',          request_id
         set_node @template, 'bxd|Timestamp',          iso_time
         set_node @template, 'bxd|Language',           @language
-        set_node @template, 'bxd|UserAgent',          "Sepa Transfer Library #{VERSION}"
+        set_node @template, 'bxd|UserAgent',          @software_id || "Sepa Transfer Library #{VERSION}"
       end
 
       def set_application_request

--- a/lib/sepa/version.rb
+++ b/lib/sepa/version.rb
@@ -1,8 +1,8 @@
 module Sepa
   # The current version of the gem
   MAJOR = 1
-  MINOR = 2
-  TINY  = 1
+  MINOR = 3
+  TINY  = 0
   PRE   = nil
 
   VERSION = [MAJOR, MINOR, TINY, PRE].compact.join('.')

--- a/lib/sepa/wsdl/wsdl_op_cert_production.xml
+++ b/lib/sepa/wsdl/wsdl_op_cert_production.xml
@@ -1,156 +1,162 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<wsdl:definitions targetNamespace="http://mlp.op.fi/OPCertificateService" xmlns:tns="http://mlp.op.fi/OPCertificateService" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<wsdl:definitions targetNamespace="http://mlp.op.fi/OPCertificateService"
+	xmlns:tns="http://mlp.op.fi/OPCertificateService" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+	xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+	xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 	<wsdl:types>
-		<xsd:schema targetNamespace="http://mlp.op.fi/OPCertificateService" elementFormDefault="qualified" attributeFormDefault="qualified">
+		<xsd:schema targetNamespace="http://mlp.op.fi/OPCertificateService"
+			elementFormDefault="qualified" attributeFormDefault="qualified">
 			<xsd:complexType name="CertificateRequestHeader">
 				<xsd:sequence>
-					<xsd:element name="SenderId" type="xsd:string" nillable="false"/>
-					<xsd:element name="RequestId" type="xsd:string" nillable="false"/>
-					<xsd:element name="Timestamp" type="xsd:dateTime" nillable="false"/>
+					<xsd:element name="SenderId" type="xsd:string" nillable="false" />
+					<xsd:element name="RequestId" type="xsd:string" nillable="false" />
+					<xsd:element name="Timestamp" type="xsd:dateTime" nillable="false" />
 				</xsd:sequence>
 			</xsd:complexType>
 			<xsd:complexType name="CertificateResponseHeader">
 				<xsd:sequence>
-					<xsd:element name="SenderId" type="xsd:string" nillable="false"/>
-					<xsd:element name="RequestId" type="xsd:string" nillable="false"/>
-					<xsd:element name="Timestamp" type="xsd:dateTime" nillable="false"/>
-					<xsd:element name="ResponseCode" type="xsd:string" nillable="true"/>
-					<xsd:element name="ResponseText" type="xsd:string" nillable="true"/>
+					<xsd:element name="SenderId" type="xsd:string" nillable="false" />
+					<xsd:element name="RequestId" type="xsd:string" nillable="false" />
+					<xsd:element name="Timestamp" type="xsd:dateTime" nillable="false" />
+					<xsd:element name="ResponseCode" type="xsd:string" nillable="true" />
+					<xsd:element name="ResponseText" type="xsd:string" nillable="true" />
 				</xsd:sequence>
 			</xsd:complexType>
 			<xsd:complexType name="GetCertificateRequest">
 				<xsd:sequence>
-					<xsd:element name="RequestHeader" type="tns:CertificateRequestHeader" nillable="false"/>
-					<xsd:element name="ApplicationRequest" type="xsd:base64Binary" nillable="false"/>
+					<xsd:element name="RequestHeader" type="tns:CertificateRequestHeader" nillable="false" />
+					<xsd:element name="ApplicationRequest" type="xsd:base64Binary" nillable="false" />
 				</xsd:sequence>
 			</xsd:complexType>
 			<xsd:complexType name="GetCertificateResponse">
 				<xsd:sequence>
-					<xsd:element name="ResponseHeader" type="tns:CertificateResponseHeader" nillable="false"/>
-					<xsd:element name="ApplicationResponse" type="xsd:base64Binary" nillable="false"/>
+					<xsd:element name="ResponseHeader" type="tns:CertificateResponseHeader" nillable="false" />
+					<xsd:element name="ApplicationResponse" type="xsd:base64Binary" nillable="false" />
 				</xsd:sequence>
 			</xsd:complexType>
 			<xsd:complexType name="GetServiceCertificatesRequest">
 				<xsd:sequence>
-					<xsd:element name="RequestHeader" type="tns:CertificateRequestHeader" nillable="false"/>
-					<xsd:element name="ApplicationRequest" type="xsd:base64Binary" nillable="false"/>
+					<xsd:element name="RequestHeader" type="tns:CertificateRequestHeader" nillable="false" />
+					<xsd:element name="ApplicationRequest" type="xsd:base64Binary" nillable="false" />
 				</xsd:sequence>
 			</xsd:complexType>
 			<xsd:complexType name="GetServiceCertificatesResponse">
 				<xsd:sequence>
-					<xsd:element name="ResponseHeader" type="tns:CertificateResponseHeader" nillable="false"/>
-					<xsd:element name="ApplicationResponse" type="xsd:base64Binary" nillable="false"/>
+					<xsd:element name="ResponseHeader" type="tns:CertificateResponseHeader" nillable="false" />
+					<xsd:element name="ApplicationResponse" type="xsd:base64Binary" nillable="false" />
 				</xsd:sequence>
 			</xsd:complexType>
 			<xsd:complexType name="RevokeCertificateRequest">
 				<xsd:sequence>
-					<xsd:element name="RequestHeader" type="tns:CertificateRequestHeader" nillable="false"/>
-					<xsd:element name="ApplicationRequest" type="xsd:base64Binary" nillable="false"/>
+					<xsd:element name="RequestHeader" type="tns:CertificateRequestHeader" nillable="false" />
+					<xsd:element name="ApplicationRequest" type="xsd:base64Binary" nillable="false" />
 				</xsd:sequence>
 			</xsd:complexType>
 			<xsd:complexType name="RevokeCertificateResponse">
 				<xsd:sequence>
-					<xsd:element name="ResponseHeader" type="tns:CertificateResponseHeader" nillable="false"/>
-					<xsd:element name="ApplicationResponse" type="xsd:base64Binary" nillable="false"/>
+					<xsd:element name="ResponseHeader" type="tns:CertificateResponseHeader" nillable="false" />
+					<xsd:element name="ApplicationResponse" type="xsd:base64Binary" nillable="false" />
 				</xsd:sequence>
 			</xsd:complexType>
 			<xsd:complexType name="CertificateServiceFaultDetail">
 				<xsd:sequence>
-					<xsd:element minOccurs="0" maxOccurs="1" name="category" type="xsd:string"/>
-					<xsd:element minOccurs="0" maxOccurs="1" name="code" type="xsd:string"/>
+					<xsd:element minOccurs="0" maxOccurs="1" name="category" type="xsd:string" />
+					<xsd:element minOccurs="0" maxOccurs="1" name="code" type="xsd:string" />
 				</xsd:sequence>
 			</xsd:complexType>
 		</xsd:schema>
-		<xsd:schema targetNamespace="http://mlp.op.fi/OPCertificateService" elementFormDefault="qualified" attributeFormDefault="qualified">
-			<xsd:element name="getCertificatein" type="tns:GetCertificateRequest"/>
-			<xsd:element name="getCertificateout" type="tns:GetCertificateResponse"/>
-			<xsd:element name="getServiceCertificatesin" type="tns:GetServiceCertificatesRequest"/>
-			<xsd:element name="getServiceCertificatesout" type="tns:GetServiceCertificatesResponse"/>
-			<xsd:element name="revokeCertificatein" type="tns:RevokeCertificateRequest"/>
-			<xsd:element name="revokeCertificateout" type="tns:RevokeCertificateResponse"/>
-			<xsd:element name="certificateServiceFaultElement" type="tns:CertificateServiceFaultDetail"/>
+		<xsd:schema targetNamespace="http://mlp.op.fi/OPCertificateService"
+			elementFormDefault="qualified" attributeFormDefault="qualified">
+			<xsd:element name="getCertificatein" type="tns:GetCertificateRequest" />
+			<xsd:element name="getCertificateout" type="tns:GetCertificateResponse" />
+			<xsd:element name="getServiceCertificatesin" type="tns:GetServiceCertificatesRequest" />
+			<xsd:element name="getServiceCertificatesout" type="tns:GetServiceCertificatesResponse" />
+			<xsd:element name="revokeCertificatein" type="tns:RevokeCertificateRequest" />
+			<xsd:element name="revokeCertificateout" type="tns:RevokeCertificateResponse" />
+			<xsd:element name="certificateServiceFaultElement" type="tns:CertificateServiceFaultDetail" />
 		</xsd:schema>
 	</wsdl:types>
 	<wsdl:message name="certificateServiceFault">
-		<wsdl:part name="certificateServiceFault" element="tns:certificateServiceFaultElement"/>
+		<wsdl:part name="certificateServiceFault" element="tns:certificateServiceFaultElement" />
 	</wsdl:message>
 	<wsdl:message name="getCertificateRequest">
-		<wsdl:part element="tns:getCertificatein" name="getCertificatein"/>
+		<wsdl:part element="tns:getCertificatein" name="getCertificatein" />
 	</wsdl:message>
 	<wsdl:message name="getCertificateResponse">
-		<wsdl:part element="tns:getCertificateout" name="getCertificateout"/>
+		<wsdl:part element="tns:getCertificateout" name="getCertificateout" />
 	</wsdl:message>
 	<wsdl:message name="getServiceCertificatesRequest">
-		<wsdl:part element="tns:getServiceCertificatesin" name="getServiceCertificatesin"/>
+		<wsdl:part element="tns:getServiceCertificatesin" name="getServiceCertificatesin" />
 	</wsdl:message>
 	<wsdl:message name="getServiceCertificatesResponse">
-		<wsdl:part element="tns:getServiceCertificatesout" name="getServiceCertificatesout"/>
+		<wsdl:part element="tns:getServiceCertificatesout" name="getServiceCertificatesout" />
 	</wsdl:message>
 	<wsdl:message name="revokeCertificateRequest">
-		<wsdl:part element="tns:revokeCertificatein" name="revokeCertificatein"/>
+		<wsdl:part element="tns:revokeCertificatein" name="revokeCertificatein" />
 	</wsdl:message>
 	<wsdl:message name="revokeCertificateResponse">
-		<wsdl:part element="tns:revokeCertificateout" name="revokeCertificateout"/>
+		<wsdl:part element="tns:revokeCertificateout" name="revokeCertificateout" />
 	</wsdl:message>
 	<wsdl:portType name="OPCertificateServicePortType">
 		<wsdl:operation name="getCertificate">
-			<wsdl:input message="tns:getCertificateRequest" name="getCertificateRequest"/>
-			<wsdl:output message="tns:getCertificateResponse" name="getCertificateResponse"/>
-			<wsdl:fault message="tns:certificateServiceFault" name="certificateServiceFault"/>
+			<wsdl:input message="tns:getCertificateRequest" name="getCertificateRequest" />
+			<wsdl:output message="tns:getCertificateResponse" name="getCertificateResponse" />
+			<wsdl:fault message="tns:certificateServiceFault" name="certificateServiceFault" />
 		</wsdl:operation>
 		<wsdl:operation name="getServiceCertificates">
-			<wsdl:input message="tns:getServiceCertificatesRequest" name="getServiceCertificatesRequest"/>
-			<wsdl:output message="tns:getServiceCertificatesResponse" name="getServiceCertificatesResponse"/>
-			<wsdl:fault message="tns:certificateServiceFault" name="certificateServiceFault"/>
+			<wsdl:input message="tns:getServiceCertificatesRequest" name="getServiceCertificatesRequest" />
+			<wsdl:output message="tns:getServiceCertificatesResponse"
+				name="getServiceCertificatesResponse" />
+			<wsdl:fault message="tns:certificateServiceFault" name="certificateServiceFault" />
 		</wsdl:operation>
 		<wsdl:operation name="revokeCertificate">
-			<wsdl:input message="tns:revokeCertificateRequest" name="revokeCertificateRequest"/>
-			<wsdl:output message="tns:revokeCertificateResponse" name="revokeCertificateResponse"/>
-			<wsdl:fault message="tns:certificateServiceFault" name="certificateServiceFault"/>
+			<wsdl:input message="tns:revokeCertificateRequest" name="revokeCertificateRequest" />
+			<wsdl:output message="tns:revokeCertificateResponse" name="revokeCertificateResponse" />
+			<wsdl:fault message="tns:certificateServiceFault" name="certificateServiceFault" />
 		</wsdl:operation>
 	</wsdl:portType>
 	<wsdl:binding name="OPCertificateServiceHttpBinding" type="tns:OPCertificateServicePortType">
-		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
 		<wsdl:operation name="getCertificate">
-			<soap:operation soapAction=""/>
+			<soap:operation soapAction="" />
 			<wsdl:input name="getCertificateRequest">
-				<soap:body use="literal"/>
+				<soap:body use="literal" />
 			</wsdl:input>
 			<wsdl:output name="getCertificateResponse">
-				<soap:body use="literal"/>
+				<soap:body use="literal" />
 			</wsdl:output>
 			<wsdl:fault name="certificateServiceFault">
-				<soap:fault use="literal"/>
+				<soap:fault use="literal" />
 			</wsdl:fault>
 		</wsdl:operation>
 		<wsdl:operation name="getServiceCertificates">
-			<soap:operation soapAction=""/>
+			<soap:operation soapAction="" />
 			<wsdl:input name="getServiceCertificatesRequest">
-				<soap:body use="literal"/>
+				<soap:body use="literal" />
 			</wsdl:input>
 			<wsdl:output name="getServiceCertificatesResponse">
-				<soap:body use="literal"/>
+				<soap:body use="literal" />
 			</wsdl:output>
 			<wsdl:fault name="certificateServiceFault">
-				<soap:fault use="literal"/>
+				<soap:fault use="literal" />
 			</wsdl:fault>
 		</wsdl:operation>
 		<wsdl:operation name="revokeCertificate">
-			<soap:operation soapAction=""/>
+			<soap:operation soapAction="" />
 			<wsdl:input name="revokeCertificateRequest">
-				<soap:body use="literal"/>
+				<soap:body use="literal" />
 			</wsdl:input>
 			<wsdl:output name="revokeCertificateResponse">
-				<soap:body use="literal"/>
+				<soap:body use="literal" />
 			</wsdl:output>
 			<wsdl:fault name="certificateServiceFault">
-				<soap:fault use="literal"/>
+				<soap:fault use="literal" />
 			</wsdl:fault>
 		</wsdl:operation>
 	</wsdl:binding>
 	<wsdl:service name="OPCertificateService">
 		<wsdl:port binding="tns:OPCertificateServiceHttpBinding" name="OPCertificateServiceHttpPort">
-			<soap:address location="https://wsk.op.fi/services/OPCertificateService"/>
+			<soap:address location="https://wsk.op.fi/services/OPCertificateServiceV2" />
 		</wsdl:port>
 	</wsdl:service>
 </wsdl:definitions>

--- a/lib/sepa/wsdl/wsdl_op_production.xml
+++ b/lib/sepa/wsdl/wsdl_op_production.xml
@@ -1,234 +1,243 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<wsdl:definitions targetNamespace="http://bxd.fi/CorporateFileService" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ns1="http://model.bxd.fi" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="http://bxd.fi/CorporateFileService" xmlns:wsdlsoap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy">
+<wsdl:definitions targetNamespace="http://bxd.fi/CorporateFileService"
+	xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ns1="http://model.bxd.fi"
+	xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+	xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+	xmlns:tns="http://bxd.fi/CorporateFileService"
+	xmlns:wsdlsoap="http://schemas.xmlsoap.org/wsdl/soap/"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy">
 	<wsdl:types>
-		<xsd:schema targetNamespace="http://model.bxd.fi" elementFormDefault="qualified" attributeFormDefault="qualified">
+		<xsd:schema targetNamespace="http://model.bxd.fi" elementFormDefault="qualified"
+			attributeFormDefault="qualified">
 			<xsd:complexType name="RequestHeader">
 				<xsd:sequence>
-					<xsd:element name="SenderId" type="xsd:string" nillable="false"/>
-					<xsd:element name="RequestId" type="xsd:string" nillable="false"/>
-					<xsd:element name="Timestamp" type="xsd:dateTime" nillable="false"/>
-					<xsd:element name="Language" type="xsd:string" nillable="true"/>
-					<xsd:element name="UserAgent" type="xsd:string" nillable="true"/>
-					<xsd:element name="ReceiverId" type="xsd:string" nillable="false"/>
+					<xsd:element name="SenderId" type="xsd:string" nillable="false" />
+					<xsd:element name="RequestId" type="xsd:string" nillable="false" />
+					<xsd:element name="Timestamp" type="xsd:dateTime" nillable="false" />
+					<xsd:element name="Language" type="xsd:string" nillable="true" />
+					<xsd:element name="UserAgent" type="xsd:string" nillable="true" />
+					<xsd:element name="ReceiverId" type="xsd:string" nillable="false" />
 				</xsd:sequence>
 			</xsd:complexType>
 			<xsd:complexType name="ResponseHeader">
 				<xsd:sequence>
-					<xsd:element name="SenderId" type="xsd:string" nillable="false"/>
-					<xsd:element name="RequestId" type="xsd:string" nillable="false"/>
-					<xsd:element name="Timestamp" type="xsd:dateTime" nillable="false"/>
-					<xsd:element name="ResponseCode" type="xsd:string" nillable="true"/>
-					<xsd:element name="ResponseText" type="xsd:string" nillable="true"/>
-					<xsd:element name="ReceiverId" type="xsd:string" nillable="false"/>
+					<xsd:element name="SenderId" type="xsd:string" nillable="false" />
+					<xsd:element name="RequestId" type="xsd:string" nillable="false" />
+					<xsd:element name="Timestamp" type="xsd:dateTime" nillable="false" />
+					<xsd:element name="ResponseCode" type="xsd:string" nillable="true" />
+					<xsd:element name="ResponseText" type="xsd:string" nillable="true" />
+					<xsd:element name="ReceiverId" type="xsd:string" nillable="false" />
 				</xsd:sequence>
 			</xsd:complexType>
 			<xsd:complexType name="UploadFileRequest">
 				<xsd:sequence>
-					<xsd:element name="RequestHeader" type="ns1:RequestHeader" nillable="false"/>
-					<xsd:element name="ApplicationRequest" type="xsd:base64Binary" nillable="false"/>
+					<xsd:element name="RequestHeader" type="ns1:RequestHeader" nillable="false" />
+					<xsd:element name="ApplicationRequest" type="xsd:base64Binary" nillable="false" />
 				</xsd:sequence>
 			</xsd:complexType>
 			<xsd:complexType name="UploadFileResponse">
 				<xsd:sequence>
-					<xsd:element name="ResponseHeader" type="ns1:ResponseHeader" nillable="false"/>
-					<xsd:element name="ApplicationResponse" type="xsd:base64Binary" nillable="false"/>
+					<xsd:element name="ResponseHeader" type="ns1:ResponseHeader" nillable="false" />
+					<xsd:element name="ApplicationResponse" type="xsd:base64Binary" nillable="false" />
 				</xsd:sequence>
 			</xsd:complexType>
 			<xsd:complexType name="DownloadFileListRequest">
 				<xsd:sequence>
-					<xsd:element name="RequestHeader" type="ns1:RequestHeader" nillable="false"/>
-					<xsd:element name="ApplicationRequest" type="xsd:base64Binary" nillable="false"/>
+					<xsd:element name="RequestHeader" type="ns1:RequestHeader" nillable="false" />
+					<xsd:element name="ApplicationRequest" type="xsd:base64Binary" nillable="false" />
 				</xsd:sequence>
 			</xsd:complexType>
 			<xsd:complexType name="DownloadFileListResponse">
 				<xsd:sequence>
-					<xsd:element name="ResponseHeader" type="ns1:ResponseHeader" nillable="false"/>
-					<xsd:element name="ApplicationResponse" type="xsd:base64Binary" nillable="false"/>
+					<xsd:element name="ResponseHeader" type="ns1:ResponseHeader" nillable="false" />
+					<xsd:element name="ApplicationResponse" type="xsd:base64Binary" nillable="false" />
 				</xsd:sequence>
 			</xsd:complexType>
 			<xsd:complexType name="DownloadFileRequest">
 				<xsd:sequence>
-					<xsd:element name="RequestHeader" type="ns1:RequestHeader" nillable="false"/>
-					<xsd:element name="ApplicationRequest" type="xsd:base64Binary" nillable="false"/>
+					<xsd:element name="RequestHeader" type="ns1:RequestHeader" nillable="false" />
+					<xsd:element name="ApplicationRequest" type="xsd:base64Binary" nillable="false" />
 				</xsd:sequence>
 			</xsd:complexType>
 			<xsd:complexType name="DownloadFileResponse">
 				<xsd:sequence>
-					<xsd:element name="ResponseHeader" type="ns1:ResponseHeader" nillable="false"/>
-					<xsd:element name="ApplicationResponse" type="xsd:base64Binary" nillable="false"/>
+					<xsd:element name="ResponseHeader" type="ns1:ResponseHeader" nillable="false" />
+					<xsd:element name="ApplicationResponse" type="xsd:base64Binary" nillable="false" />
 				</xsd:sequence>
 			</xsd:complexType>
 			<xsd:complexType name="DeleteFileRequest">
 				<xsd:sequence>
-					<xsd:element name="RequestHeader" type="ns1:RequestHeader" nillable="false"/>
-					<xsd:element name="ApplicationRequest" type="xsd:base64Binary" nillable="false"/>
+					<xsd:element name="RequestHeader" type="ns1:RequestHeader" nillable="false" />
+					<xsd:element name="ApplicationRequest" type="xsd:base64Binary" nillable="false" />
 				</xsd:sequence>
 			</xsd:complexType>
 			<xsd:complexType name="DeleteFileResponse">
 				<xsd:sequence>
-					<xsd:element name="ResponseHeader" type="ns1:ResponseHeader" nillable="false"/>
-					<xsd:element name="ApplicationResponse" type="xsd:base64Binary" nillable="false"/>
+					<xsd:element name="ResponseHeader" type="ns1:ResponseHeader" nillable="false" />
+					<xsd:element name="ApplicationResponse" type="xsd:base64Binary" nillable="false" />
 				</xsd:sequence>
 			</xsd:complexType>
 			<xsd:complexType name="GetUserInfoRequest">
 				<xsd:sequence>
-					<xsd:element name="RequestHeader" type="ns1:RequestHeader" nillable="false"/>
-					<xsd:element name="ApplicationRequest" type="xsd:base64Binary" nillable="false"/>
+					<xsd:element name="RequestHeader" type="ns1:RequestHeader" nillable="false" />
+					<xsd:element name="ApplicationRequest" type="xsd:base64Binary" nillable="false" />
 				</xsd:sequence>
 			</xsd:complexType>
 			<xsd:complexType name="GetUserInfoResponse">
 				<xsd:sequence>
-					<xsd:element name="ResponseHeader" type="ns1:ResponseHeader" nillable="false"/>
-					<xsd:element name="ApplicationResponse" type="xsd:base64Binary" nillable="false"/>
+					<xsd:element name="ResponseHeader" type="ns1:ResponseHeader" nillable="false" />
+					<xsd:element name="ApplicationResponse" type="xsd:base64Binary" nillable="false" />
 				</xsd:sequence>
 			</xsd:complexType>
 			<xsd:complexType name="FileServiceFaultDetail">
 				<xsd:sequence>
-					<xsd:element minOccurs="0" maxOccurs="1" name="category" type="xsd:string"/>
-					<xsd:element minOccurs="0" maxOccurs="1" name="code" type="xsd:string"/>
+					<xsd:element minOccurs="0" maxOccurs="1" name="category" type="xsd:string" />
+					<xsd:element minOccurs="0" maxOccurs="1" name="code" type="xsd:string" />
 				</xsd:sequence>
 			</xsd:complexType>
 		</xsd:schema>
-		<xsd:schema targetNamespace="http://bxd.fi/CorporateFileService" elementFormDefault="qualified" attributeFormDefault="qualified">
-			<xsd:element name="uploadFilein" type="ns1:UploadFileRequest"/>
-			<xsd:element name="uploadFileout" type="ns1:UploadFileResponse"/>
-			<xsd:element name="downloadFileListin" type="ns1:DownloadFileListRequest"/>
-			<xsd:element name="downloadFileListout" type="ns1:DownloadFileListResponse"/>
-			<xsd:element name="downloadFilein" type="ns1:DownloadFileRequest"/>
-			<xsd:element name="downloadFileout" type="ns1:DownloadFileResponse"/>
-			<xsd:element name="deleteFilein" type="ns1:DeleteFileRequest"/>
-			<xsd:element name="deleteFileout" type="ns1:DeleteFileResponse"/>
-			<xsd:element name="getUserInfoin" type="ns1:GetUserInfoRequest"/>
-			<xsd:element name="getUserInfoout" type="ns1:GetUserInfoResponse"/>
-			<xsd:element name="FileServiceFaultElement" type="ns1:FileServiceFaultDetail"/>
+		<xsd:schema targetNamespace="http://bxd.fi/CorporateFileService" elementFormDefault="qualified"
+			attributeFormDefault="qualified">
+			<xsd:element name="uploadFilein" type="ns1:UploadFileRequest" />
+			<xsd:element name="uploadFileout" type="ns1:UploadFileResponse" />
+			<xsd:element name="downloadFileListin" type="ns1:DownloadFileListRequest" />
+			<xsd:element name="downloadFileListout" type="ns1:DownloadFileListResponse" />
+			<xsd:element name="downloadFilein" type="ns1:DownloadFileRequest" />
+			<xsd:element name="downloadFileout" type="ns1:DownloadFileResponse" />
+			<xsd:element name="deleteFilein" type="ns1:DeleteFileRequest" />
+			<xsd:element name="deleteFileout" type="ns1:DeleteFileResponse" />
+			<xsd:element name="getUserInfoin" type="ns1:GetUserInfoRequest" />
+			<xsd:element name="getUserInfoout" type="ns1:GetUserInfoResponse" />
+			<xsd:element name="FileServiceFaultElement" type="ns1:FileServiceFaultDetail" />
 		</xsd:schema>
 	</wsdl:types>
 	<wsdl:message name="FileServiceFault">
-		<wsdl:part name="FileServiceFault" element="tns:FileServiceFaultElement"/>
+		<wsdl:part name="FileServiceFault" element="tns:FileServiceFaultElement" />
 	</wsdl:message>
 	<wsdl:message name="uploadFileResponse">
-		<wsdl:part element="tns:uploadFileout" name="uploadFileout"/>
+		<wsdl:part element="tns:uploadFileout" name="uploadFileout" />
 	</wsdl:message>
 	<wsdl:message name="uploadFileRequest">
-		<wsdl:part element="tns:uploadFilein" name="uploadFilein"/>
+		<wsdl:part element="tns:uploadFilein" name="uploadFilein" />
 	</wsdl:message>
 	<wsdl:message name="downloadFileListResponse">
-		<wsdl:part element="tns:downloadFileListout" name="downloadFileListout"/>
+		<wsdl:part element="tns:downloadFileListout" name="downloadFileListout" />
 	</wsdl:message>
 	<wsdl:message name="downloadFileListRequest">
-		<wsdl:part element="tns:downloadFileListin" name="downloadFileListin"/>
+		<wsdl:part element="tns:downloadFileListin" name="downloadFileListin" />
 	</wsdl:message>
 	<wsdl:message name="downloadFileResponse">
-		<wsdl:part element="tns:downloadFileout" name="downloadFileout"/>
+		<wsdl:part element="tns:downloadFileout" name="downloadFileout" />
 	</wsdl:message>
 	<wsdl:message name="downloadFileRequest">
-		<wsdl:part element="tns:downloadFilein" name="downloadFilein"/>
+		<wsdl:part element="tns:downloadFilein" name="downloadFilein" />
 	</wsdl:message>
 	<wsdl:message name="deleteFileResponse">
-		<wsdl:part element="tns:deleteFileout" name="deleteFileout"/>
+		<wsdl:part element="tns:deleteFileout" name="deleteFileout" />
 	</wsdl:message>
 	<wsdl:message name="deleteFileRequest">
-		<wsdl:part element="tns:deleteFilein" name="deleteFilein"/>
+		<wsdl:part element="tns:deleteFilein" name="deleteFilein" />
 	</wsdl:message>
 	<wsdl:message name="getUserInfoRequest">
-		<wsdl:part element="tns:getUserInfoin" name="getUserInfoin"/>
+		<wsdl:part element="tns:getUserInfoin" name="getUserInfoin" />
 	</wsdl:message>
 	<wsdl:message name="getUserInfoResponse">
-		<wsdl:part element="tns:getUserInfoout" name="getUserInfoout"/>
+		<wsdl:part element="tns:getUserInfoout" name="getUserInfoout" />
 	</wsdl:message>
 	<wsdl:portType name="CorporateFileServicePortType">
 		<wsdl:operation name="uploadFile">
-			<wsdl:input message="tns:uploadFileRequest" name="uploadFileRequest"/>
-			<wsdl:output message="tns:uploadFileResponse" name="uploadFileResponse"/>
-			<wsdl:fault name="FileServiceFault" message="tns:FileServiceFault"/>
+			<wsdl:input message="tns:uploadFileRequest" name="uploadFileRequest" />
+			<wsdl:output message="tns:uploadFileResponse" name="uploadFileResponse" />
+			<wsdl:fault name="FileServiceFault" message="tns:FileServiceFault" />
 		</wsdl:operation>
 		<wsdl:operation name="downloadFileList">
-			<wsdl:input message="tns:downloadFileListRequest" name="downloadFileListRequest"/>
-			<wsdl:output message="tns:downloadFileListResponse" name="downloadFileListResponse"/>
-			<wsdl:fault name="FileServiceFault" message="tns:FileServiceFault"/>
+			<wsdl:input message="tns:downloadFileListRequest" name="downloadFileListRequest" />
+			<wsdl:output message="tns:downloadFileListResponse" name="downloadFileListResponse" />
+			<wsdl:fault name="FileServiceFault" message="tns:FileServiceFault" />
 		</wsdl:operation>
 		<wsdl:operation name="downloadFile">
-			<wsdl:input message="tns:downloadFileRequest" name="downloadFileRequest"/>
-			<wsdl:output message="tns:downloadFileResponse" name="downloadFileResponse"/>
-			<wsdl:fault name="FileServiceFault" message="tns:FileServiceFault"/>
+			<wsdl:input message="tns:downloadFileRequest" name="downloadFileRequest" />
+			<wsdl:output message="tns:downloadFileResponse" name="downloadFileResponse" />
+			<wsdl:fault name="FileServiceFault" message="tns:FileServiceFault" />
 		</wsdl:operation>
 		<wsdl:operation name="deleteFile">
-			<wsdl:input message="tns:deleteFileRequest" name="deleteFileRequest"/>
-			<wsdl:output message="tns:deleteFileResponse" name="deleteFileResponse"/>
-			<wsdl:fault name="FileServiceFault" message="tns:FileServiceFault"/>
+			<wsdl:input message="tns:deleteFileRequest" name="deleteFileRequest" />
+			<wsdl:output message="tns:deleteFileResponse" name="deleteFileResponse" />
+			<wsdl:fault name="FileServiceFault" message="tns:FileServiceFault" />
 		</wsdl:operation>
 		<wsdl:operation name="getUserInfo">
-			<wsdl:input message="tns:getUserInfoRequest" name="getUserInfoRequest"/>
-			<wsdl:output message="tns:getUserInfoResponse" name="getUserInfoResponse"/>
-			<wsdl:fault name="FileServiceFault" message="tns:FileServiceFault"/>
+			<wsdl:input message="tns:getUserInfoRequest" name="getUserInfoRequest" />
+			<wsdl:output message="tns:getUserInfoResponse" name="getUserInfoResponse" />
+			<wsdl:fault name="FileServiceFault" message="tns:FileServiceFault" />
 		</wsdl:operation>
 	</wsdl:portType>
 	<wsdl:binding name="CorporateFileServiceHttpBinding" type="tns:CorporateFileServicePortType">
-		<wsdlsoap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdlsoap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
 		<wsdl:operation name="uploadFile">
-			<wsdlsoap:operation soapAction=""/>
+			<wsdlsoap:operation soapAction="" />
 			<wsdl:input name="uploadFileRequest">
-				<wsdlsoap:body use="literal"/>
+				<wsdlsoap:body use="literal" />
 			</wsdl:input>
 			<wsdl:output name="uploadFileResponse">
-				<wsdlsoap:body use="literal"/>
+				<wsdlsoap:body use="literal" />
 			</wsdl:output>
 			<wsdl:fault name="FileServiceFault">
-				<wsdlsoap:fault use="literal" name="FileServiceFault"/>
+				<wsdlsoap:fault use="literal" name="FileServiceFault" />
 			</wsdl:fault>
 		</wsdl:operation>
 		<wsdl:operation name="downloadFileList">
-			<wsdlsoap:operation soapAction=""/>
+			<wsdlsoap:operation soapAction="" />
 			<wsdl:input name="downloadFileListRequest">
-				<wsdlsoap:body use="literal"/>
+				<wsdlsoap:body use="literal" />
 			</wsdl:input>
 			<wsdl:output name="downloadFileListResponse">
-				<wsdlsoap:body use="literal"/>
+				<wsdlsoap:body use="literal" />
 			</wsdl:output>
 			<wsdl:fault name="FileServiceFault">
-				<wsdlsoap:fault use="literal" name="FileServiceFault"/>
+				<wsdlsoap:fault use="literal" name="FileServiceFault" />
 			</wsdl:fault>
 		</wsdl:operation>
 		<wsdl:operation name="downloadFile">
-			<wsdlsoap:operation soapAction=""/>
+			<wsdlsoap:operation soapAction="" />
 			<wsdl:input name="downloadFileRequest">
-				<wsdlsoap:body use="literal"/>
+				<wsdlsoap:body use="literal" />
 			</wsdl:input>
 			<wsdl:output name="downloadFileResponse">
-				<wsdlsoap:body use="literal"/>
+				<wsdlsoap:body use="literal" />
 			</wsdl:output>
 			<wsdl:fault name="FileServiceFault">
-				<wsdlsoap:fault use="literal" name="FileServiceFault"/>
+				<wsdlsoap:fault use="literal" name="FileServiceFault" />
 			</wsdl:fault>
 		</wsdl:operation>
 		<wsdl:operation name="deleteFile">
-			<wsdlsoap:operation soapAction=""/>
+			<wsdlsoap:operation soapAction="" />
 			<wsdl:input name="deleteFileRequest">
-				<wsdlsoap:body use="literal"/>
+				<wsdlsoap:body use="literal" />
 			</wsdl:input>
 			<wsdl:output name="deleteFileResponse">
-				<wsdlsoap:body use="literal"/>
+				<wsdlsoap:body use="literal" />
 			</wsdl:output>
 			<wsdl:fault name="FileServiceFault">
-				<wsdlsoap:fault use="literal" name="FileServiceFault"/>
+				<wsdlsoap:fault use="literal" name="FileServiceFault" />
 			</wsdl:fault>
 		</wsdl:operation>
 		<wsdl:operation name="getUserInfo">
-			<wsdlsoap:operation soapAction=""/>
+			<wsdlsoap:operation soapAction="" />
 			<wsdl:input name="getUserInfoRequest">
-				<wsdlsoap:body use="literal"/>
+				<wsdlsoap:body use="literal" />
 			</wsdl:input>
 			<wsdl:output name="getUserInfoResponse">
-				<wsdlsoap:body use="literal"/>
+				<wsdlsoap:body use="literal" />
 			</wsdl:output>
 			<wsdl:fault name="FileServiceFault">
-				<wsdlsoap:fault use="literal" name="FileServiceFault"/>
+				<wsdlsoap:fault use="literal" name="FileServiceFault" />
 			</wsdl:fault>
 		</wsdl:operation>
 	</wsdl:binding>
 	<wsdl:service name="CorporateFileService">
 		<wsdl:port binding="tns:CorporateFileServiceHttpBinding" name="CorporateFileServiceHttpPort">
-			<wsdlsoap:address location="https://wsk.op.fi/services/CorporateFileService"/>
+			<wsdlsoap:address location="https://wsk.op.fi/services/CorporateFileServiceV2" />
 		</wsdl:port>
 	</wsdl:service>
 </wsdl:definitions>

--- a/sepafm.gemspec
+++ b/sepafm.gemspec
@@ -19,12 +19,12 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.1'
 
   spec.add_dependency 'activemodel', '>= 4.2'
-  spec.add_dependency 'nokogiri', '~> 1.15'
-  spec.add_dependency 'savon', '~> 2.14'
+  spec.add_dependency 'nokogiri'
+  spec.add_dependency 'savon', '< 3.0'
 
-  spec.add_development_dependency 'bundler', '~> 2.4.18'
-  spec.add_development_dependency 'minitest', '~> 5.19'
-  spec.add_development_dependency 'rake', '~> 13.0.6'
-  spec.add_development_dependency 'byebug', '~> 11.1.3'
-  spec.add_development_dependency 'simplecov', '~> 0.22.0'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'minitest'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'byebug'
+  spec.add_development_dependency 'simplecov'
 end

--- a/test/sepa/banks/danske/danske_cert_response_test.rb
+++ b/test/sepa/banks/danske/danske_cert_response_test.rb
@@ -80,7 +80,7 @@ class DanskeCertResponseTest < ActiveSupport::TestCase
   end
 
   test 'hashes shouldnt match when data is corrupted' do
-    assert_output(/These digests failed to verify: {"#response"=>{:digest=>"2vCYl3h7ksRgk7IyV2axgpXxTWM=", :digest_method=>:sha1}}/) do
+    assert_output(/These digests failed to verify: {\"#response\" => {digest: \"2vCYl3h7ksRgk7IyV2axgpXxTWM=\", digest_method: :sha1}}/) do
       refute @create_certificate_corrupted_response.hashes_match?(verbose: true)
     end
   end

--- a/test/sepa/banks/op/op_cert_application_request_test.rb
+++ b/test/sepa/banks/op/op_cert_application_request_test.rb
@@ -65,4 +65,10 @@ class OpCertApplicationRequestTest < ActiveSupport::TestCase
   test "validates against schema" do
     assert_valid_against_schema 'op/CertApplicationRequest_200812.xsd', @xml
   end
+
+  test "software id can be configured" do
+    ar_cert = Sepa::SoapBuilder.new(@op_get_certificate_params.merge({software_id: "Custom Software ID"})).application_request
+    xml = Nokogiri::XML(ar_cert.to_xml)
+    assert_equal xml.at_css("SoftwareId").content, "Custom Software ID"
+  end
 end

--- a/test/sepa/banks/op/op_renew_cert_application_request_test.rb
+++ b/test/sepa/banks/op/op_renew_cert_application_request_test.rb
@@ -27,8 +27,8 @@ class OpRenewCertApplicationRequestTest < ActiveSupport::TestCase
     @doc.at("xmlns|Signature", xmlns: 'http://www.w3.org/2000/09/xmldsig#').remove
 
     # Calculate digest
-    sha1          = OpenSSL::Digest::SHA1.new
-    actual_digest = encode(sha1.digest(@doc.canonicalize))
+    sha256          = OpenSSL::Digest::SHA256.new
+    actual_digest = encode(sha256.digest(@doc.canonicalize))
 
     # And then make sure the two are equal
     assert_equal actual_digest.strip, calculated_digest.strip

--- a/test/sepa/sepa_test.rb
+++ b/test/sepa/sepa_test.rb
@@ -3,6 +3,6 @@ require 'test_helper'
 class TestSepa < ActiveSupport::TestCase
   test 'version is defined correctly' do
     refute_nil Sepa::VERSION
-    assert_equal '1.2.1', Sepa::VERSION
+    assert_equal '1.3.0', Sepa::VERSION
   end
 end


### PR DESCRIPTION
Update OP WSDL to v2. Use sha256 digest method for OP

Allow newer gem dependencies for nokogiri and savon and the development dependencies. 

Allow giving software_id in client params which is used in the requests